### PR TITLE
Add subdomain concept

### DIFF
--- a/jqassistant/business.adoc
+++ b/jqassistant/business.adoc
@@ -1,0 +1,31 @@
+[[business:Default]]
+[role=group,includesConcepts="business:Subdomain"]
+== Business
+
+This section describes the application from the business' perspective.
+
+=== Concepts
+
+The Spring PetClinic application consists of several business subdomains that can be identified by naming conventions.
+
+[[business:Subdomain]]
+.Creates predefined Subdomain nodes and connects them to all Type nodes via naming conventions.
+[source,cypher,role=concept]
+----
+UNWIND [
+    { name: "Clinic" },
+    { name: "Owner" },
+    { name: "Person" }, 
+    { name: "Pet" },
+    { name: "Specialty" },
+    { name: "Vet" }, 
+    { name: "Visit" }
+]
+AS properties
+CREATE (s:Subdomain) SET s = properties
+WITH s
+    MATCH (t:Type)
+        WHERE t.name CONTAINS s.name
+    MERGE (t)-[:BELONGS_TO]->(s)
+RETURN s.name as Subdomain, COUNT(t) as Types
+----

--- a/jqassistant/index.adoc
+++ b/jqassistant/index.adoc
@@ -17,10 +17,11 @@ should apply a layout, e.g. menu:Layout[Hierarchical].
 The following rule groups are executed during a build:
 
 [[default]]
-[role=group,includesGroups="package:Default,spring-component:Default,model:Default,management:Default,test:Default,vcs:Default"]
+[role=group,includesGroups="package:Default,spring-component:Default,model:Default,business:Default,management:Default,test:Default,vcs:Default"]
 - <<spring-component:Default>>
 - <<package:Default>>
 - <<model:Default>>
+- <<business:Default>>
 - <<management:Default>>
 - <<test:Default>>
 - <<vcs:Default>>
@@ -29,6 +30,7 @@ include::maven.adoc[]
 include::package.adoc[]
 include::spring-component.adoc[]
 include::model.adoc[]
+include::business.adoc[]
 include::management.adoc[]
 include::test.adoc[]
 include::vcs.adoc[]


### PR DESCRIPTION
Add a new concept that connects types to subdomain information via naming conventions.

This change shows that it is possible to map code parts to business' subdomains that business people are able to understand.